### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Creating a destop application with Tauri and SvelteKit
+# Creating a desktop application with Tauri and SvelteKit
 
 The resulting example code of this tutorial is available on [Github](https://github.com/Stijn-B/tauri-sveltekit-example)
 


### PR DESCRIPTION
I think the word "Desktop" is misspelled in the README.